### PR TITLE
fix: enable play and pause controls for Lottie animation via window.WL

### DIFF
--- a/src/js/Main.js
+++ b/src/js/Main.js
@@ -24,21 +24,17 @@ class Main {
   events() {
     if (this.DOM.playBtn) {
       this.DOM.playBtn.addEventListener('click', () => {
-        this.lottieInstances.forEach(instance => {
-          if (instance && typeof instance.play === 'function') {
-            instance.play();
-          }
-        });
+        if (window.WL && window.WL['lottieSection']) {
+          window.WL['lottieSection'].play();
+        }
       });
     }
 
     if (this.DOM.pauseBtn) {
       this.DOM.pauseBtn.addEventListener('click', () => {
-        this.lottieInstances.forEach(instance => {
-          if (instance && typeof instance.pause === 'function') {
-            instance.pause();
-          }
-        });
+        if (window.WL && window.WL['lottieSection']) {
+          window.WL['lottieSection'].pause();
+        }
       });
     }
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -129,7 +129,7 @@ import Layout from '@layouts/Layout.astro';
       </div>
       <div class="f--row">
         <div class="f--col-4 f--offset-4">
-          <div class="js--lottie-element c--lottie-a"></div>
+          <div class="js--lottie-element c--lottie-a" data-name="lottieSection"></div>
         </div>
       </div>
       <div class="f--row">


### PR DESCRIPTION
**Problem**:
  The play and pause buttons for the Lottie animation did not work.

**Root cause**:

- Tried to control Lottie using direct instances from `preloadLotties`, which caused errors due to inconsistent return types.
- Did not use the recommended global control method from the Terra Helpers documentation.


**Solution**:

- Updated event listeners to use `window.WL['lottieSection']` for play and pause, following the official documentation.
- Ensured the Lottie container uses the correct `data-name` attribute for global access.